### PR TITLE
Merge custom swarm handoffs

### DIFF
--- a/config/model_config_swarm.yaml
+++ b/config/model_config_swarm.yaml
@@ -923,6 +923,13 @@ app:
     swarm:
       model: *tool_calling_llm
       default_agent: *general
+      handoffs:
+        general: ~ 
+        diy: 
+          - "product"
+          - *inventory
+          - *recommendation
+        inventory: []
 
 # =============================================================================
 # UNITY CATALOG FUNCTIONS DEPLOYMENT

--- a/config/model_config_swarm.yaml
+++ b/config/model_config_swarm.yaml
@@ -920,15 +920,61 @@ app:
     # supervisor:                                     # Supervisor orchestration pattern
     #   model: *tool_calling_llm                      # LLM for routing decisions
     #   default_agent: *general                       # Default agent when no specific match
+    # SWARM ORCHESTRATION PATTERN
+    # ========================================================================
+    # Swarm orchestration enables agents to collaborate directly through 
+    # handoff tools, creating a more flexible agent-to-agent communication
+    # pattern compared to the supervisor model.
+    #
+    # Key Differences from Supervisor Pattern:
+    # - No central supervisor making routing decisions
+    # - Agents can directly hand off conversations to other agents
+    # - Each agent gets handoff tools based on the handoffs configuration
+    # - More autonomous agent behavior and peer-to-peer collaboration
+    #
+    # Implementation Details (see retail_ai/graph.py):
+    # - Uses LangGraph's create_swarm() function for orchestration
+    # - Each agent receives handoff tools via _handoffs_for_agent()
+    # - Handoff tools use each target agent's handoff_prompt as description
+    # - If no specific handoffs defined, agent can hand off to any agent
+    # ========================================================================
     swarm:
+      # LLM used for swarm coordination and agent decision-making
+      # This model powers the underlying swarm orchestration logic
       model: *tool_calling_llm
+      
+      # Starting agent for new conversations - acts as the entry point
+      # Users initially interact with this agent before potential handoffs
       default_agent: *general
+      
+      # Handoff configuration: defines which agents can transfer to which other agents
+      # Structure: {agent_name: [list_of_target_agents_or_null]}
+      # 
+      # Special Values:
+      # - ~ (null): Agent can hand off to ANY agent in the system
+      # - []: Empty list means agent has no specific handoff capabilities  
+      # - ["agent1", "agent2"]: Agent can only hand off to specified agents
+      #
+      # How Handoffs Work:
+      # 1. Each agent gets handoff tools created based on this configuration
+      # 2. Handoff tools use the target agent's handoff_prompt to describe when to transfer
+      # 3. Agents can invoke handoff tools to transfer conversations seamlessly
+      # 4. The receiving agent continues the conversation with full context
       handoffs:
+        # General agent can hand off to any agent (~ means null/any)
+        # This makes general agent the universal router for initial triage
         general: ~ 
+        
+        # DIY agent can hand off to specific product and recommendation agents
+        # This creates a focused workflow: DIY -> Product Info -> Inventory -> Recommendations
         diy: 
-          - "product"
-          - *inventory
-          - *recommendation
+          - "product"      # String reference to product agent
+          - *inventory     # YAML anchor reference to inventory agent  
+          - *recommendation # YAML anchor reference to recommendation agent
+        
+        # Inventory agent has no outbound handoffs (empty list)
+        # This makes inventory a "terminal" agent that completes conversations
+        # Users would need to start new conversations or other agents hand off elsewhere
         inventory: []
 
 # =============================================================================

--- a/notebooks/01_ingest_and_transform.py
+++ b/notebooks/01_ingest_and_transform.py
@@ -111,6 +111,7 @@ for dataset in datasets:
   ddl_path: Path = Path(dataset.ddl)
   data_path: Path = current_dir / Path(dataset.data)
   format: str = dataset.format
+  read_options: dict[str, Any] = dataset.read_options or {}
 
   statements: Sequence[str] = [s for s in re.split(r"\s*;\s*", ddl_path.read_text()) if s]
   for statement in statements:
@@ -123,7 +124,7 @@ for dataset in datasets:
           print(statement)
           spark.sql(statement, args={"database": dataset.table.schema_model.full_name})
   else:
-      spark.read.format(format).load(data_path.as_posix()).write.mode("overwrite").saveAsTable(table)
+      spark.read.format(format).options(**read_options).load(data_path.as_posix()).write.mode("overwrite").saveAsTable(table)
 
 # COMMAND ----------
 

--- a/notebooks/01_ingest_and_transform.py
+++ b/notebooks/01_ingest_and_transform.py
@@ -128,6 +128,5 @@ for dataset in datasets:
 
 # COMMAND ----------
 
-
 for dataset in config.datasets:
   display(spark.table(dataset.table.full_name))

--- a/retail_ai/config.py
+++ b/retail_ai/config.py
@@ -445,7 +445,7 @@ class SupervisorModel(BaseModel):
 class SwarmModel(BaseModel):
     model: LLMModel
     default_agent: AgentModel | str
-    handoffs: Optional[dict[str, list[AgentModel | str]]] = Field(default_factory=dict)
+    handoffs: Optional[dict[str, Optional[list[AgentModel | str]]]] = Field(default_factory=dict)
 
 
 class OrchestrationModel(BaseModel):

--- a/retail_ai/config.py
+++ b/retail_ai/config.py
@@ -536,6 +536,7 @@ class DatasetModel(BaseModel):
     ddl: str
     data: str
     format: DatasetFormat
+    read_options: Optional[dict[str, Any]] = Field(default_factory=dict)
 
 
 class UnityCatalogFunctionSqlTestModel(BaseModel):

--- a/retail_ai/config.py
+++ b/retail_ai/config.py
@@ -445,7 +445,7 @@ class SupervisorModel(BaseModel):
 class SwarmModel(BaseModel):
     model: LLMModel
     default_agent: AgentModel | str
-    handoffs: Optional[dict[str, AgentModel | str]] = Field(default_factory=dict)
+    handoffs: Optional[dict[str, list[AgentModel | str]]] = Field(default_factory=dict)
 
 
 class OrchestrationModel(BaseModel):

--- a/retail_ai/graph.py
+++ b/retail_ai/graph.py
@@ -86,6 +86,7 @@ def _handoffs_for_agent(agent: AgentModel, config: AppConfig) -> Sequence[BaseTo
             continue
         if agent.name == handoff_to_agent.name:
             continue
+        logger.debug(f"Creating handoff tool from agent {agent.name} to {handoff_to_agent.name}")
         handoff_tools.append(
             create_handoff_tool(
                 agent_name=handoff_to_agent.name,

--- a/retail_ai/graph.py
+++ b/retail_ai/graph.py
@@ -77,8 +77,9 @@ def _handoffs_for_agent(agent: AgentModel, config: AppConfig) -> Sequence[BaseTo
     for handoff_to_agent in agent_handoffs:
         if isinstance(handoff_to_agent, str):
             handoff_to_agent = next(
-                config.find_agents(lambda a: a.name == handoff_to_agent), None
+                iter(config.find_agents(lambda a: a.name == handoff_to_agent)), None
             )
+
         if handoff_to_agent is None:
             logger.warning(
                 f"Handoff agent {handoff_to_agent} not found in configuration for agent {agent.name}"
@@ -86,7 +87,9 @@ def _handoffs_for_agent(agent: AgentModel, config: AppConfig) -> Sequence[BaseTo
             continue
         if agent.name == handoff_to_agent.name:
             continue
-        logger.debug(f"Creating handoff tool from agent {agent.name} to {handoff_to_agent.name}")
+        logger.debug(
+            f"Creating handoff tool from agent {agent.name} to {handoff_to_agent.name}"
+        )
         handoff_tools.append(
             create_handoff_tool(
                 agent_name=handoff_to_agent.name,

--- a/retail_ai/graph.py
+++ b/retail_ai/graph.py
@@ -70,9 +70,9 @@ def _handoffs_for_agent(agent: AgentModel, config: AppConfig) -> Sequence[BaseTo
     handoffs: dict[str, Sequence[AgentModel | str]] = (
         config.app.orchestration.swarm.handoffs or {}
     )
-    agent_handoffs: Sequence[AgentModel | str] = handoffs.get(
-        agent.name, config.app.agents
-    )
+    agent_handoffs: Sequence[AgentModel | str] = handoffs.get(agent.name)
+    if agent_handoffs is None:
+        agent_handoffs = config.app.agents
 
     for handoff_to_agent in agent_handoffs:
         if isinstance(handoff_to_agent, str):

--- a/retail_ai/graph.py
+++ b/retail_ai/graph.py
@@ -1,5 +1,6 @@
-from typing import Any, Callable, Sequence
+from typing import Callable, Sequence
 
+from langchain_core.tools import BaseTool
 from langgraph.graph import END, StateGraph
 from langgraph.graph.state import CompiledStateGraph
 from langgraph_swarm import create_handoff_tool, create_swarm
@@ -63,22 +64,45 @@ def _create_supervisor_graph(config: AppConfig) -> CompiledStateGraph:
     return workflow.compile()
 
 
+def _handoffs_for_agent(agent: AgentModel, config: AppConfig) -> Sequence[BaseTool]:
+    handoff_tools: list[BaseTool] = []
+
+    handoffs: dict[str, Sequence[AgentModel | str]] = (
+        config.app.orchestration.swarm.handoffs or {}
+    )
+    agent_handoffs: Sequence[AgentModel | str] = handoffs.get(
+        agent.name, config.app.agents
+    )
+
+    for handoff_to_agent in agent_handoffs:
+        if isinstance(handoff_to_agent, str):
+            handoff_to_agent = next(
+                config.find_agents(lambda a: a.name == handoff_to_agent), None
+            )
+        if handoff_to_agent is None:
+            logger.warning(
+                f"Handoff agent {handoff_to_agent} not found in configuration for agent {agent.name}"
+            )
+            continue
+        if agent.name == handoff_to_agent.name:
+            continue
+        handoff_tools.append(
+            create_handoff_tool(
+                agent_name=handoff_to_agent.name,
+                description=f"Ask {handoff_to_agent.name} for help with: "
+                + handoff_to_agent.handoff_prompt,
+            )
+        )
+    return handoff_tools
+
+
 def _create_swarm_graph(config: AppConfig) -> CompiledStateGraph:
     logger.debug("Creating swarm graph")
     agents: list[CompiledStateGraph] = []
     for registered_agent in config.app.agents:
-        handoff_tools: list[Callable[..., Any]] = []
-        for handoff_to_agent in config.app.agents:
-            if registered_agent.name == handoff_to_agent.name:
-                continue
-            handoff_tools.append(
-                create_handoff_tool(
-                    agent_name=handoff_to_agent.name,
-                    description=f"Ask {handoff_to_agent.name} for help with: "
-                    + handoff_to_agent.handoff_prompt,
-                )
-            )
-        # Create agent directly using create_react_agent instead of create_agent_node
+        handoff_tools: Sequence[BaseTool] = _handoffs_for_agent(
+            agent=registered_agent, config=config
+        )
         agents.append(
             create_agent_node(agent=registered_agent, additional_tools=handoff_tools)
         )

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -1060,17 +1060,24 @@
           "anyOf": [
             {
               "additionalProperties": {
-                "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/$defs/AgentModel"
+                "anyOf": [
+                  {
+                    "items": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/$defs/AgentModel"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
                     },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
-                "type": "array"
+                    "type": "array"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               },
               "type": "object"
             },

--- a/schemas/model_config_schema.json
+++ b/schemas/model_config_schema.json
@@ -289,6 +289,18 @@
         },
         "format": {
           "$ref": "#/$defs/DatasetFormat"
+        },
+        "read_options": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Read Options"
         }
       },
       "required": [
@@ -1048,14 +1060,17 @@
           "anyOf": [
             {
               "additionalProperties": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/AgentModel"
-                  },
-                  {
-                    "type": "string"
-                  }
-                ]
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/AgentModel"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "type": "array"
               },
               "type": "object"
             },


### PR DESCRIPTION
Allow for custom handoffs to be configured in the swarm orchestration configuration

Agents not provided in the handoffs are assumed to route to all other agents
... 

handoffs:
  # General agent can hand off to any agent (~ means null/any)
  # This makes general agent the universal router for initial triage
  general: ~ 
  
  # DIY agent can hand off to specific product and recommendation agents
  # This creates a focused workflow: DIY -> Product Info -> Inventory -> Recommendations
  diy: 
    - "product"      # String reference to product agent
    - *inventory     # YAML anchor reference to inventory agent  
    - *recommendation # YAML anchor reference to recommendation agent
  
  # Inventory agent has no outbound handoffs (empty list)
  # This makes inventory a "terminal" agent that completes conversations
  # Users would need to start new conversations or other agents hand off elsewhere
  inventory: []